### PR TITLE
Fix for PHP7 change in handling of $$variable[arrayIndex]

### DIFF
--- a/PHT.php
+++ b/PHT.php
@@ -233,7 +233,7 @@ class CHPPConnection
 		foreach($result as $val)
 		{
 			$t = explode('=', $val);
-			$$t[0] = urldecode($t[1]);
+			${$t[0]} = urldecode($t[1]);
 		}
 		$this->log("[OAUTH] Request token: ".$oauth_token);
 		$this->log("[OAUTH] Request token secret: ".$oauth_token_secret);
@@ -276,7 +276,7 @@ class CHPPConnection
 		foreach($result as $val)
 		{
 			$t = explode('=', $val);
-			$$t[0] = urldecode($t[1]);
+			${$t[0]} = urldecode($t[1]);
 		}
 		if(isset($oauth_token))
 		{


### PR DESCRIPTION
In PHP7 the handling of $$variable[arrayIndex] changed. Default in PHP5 and before was ${$variable[arrayIndex]}. In PHP7 the behavior changed to ($$variable)[arrayIndex]. For this reason it is now required to manually use the {} brackets if the required behavior is the PHP5 one.