### PR TITLE
fix for HTI

### DIFF
--- a/PHT.php
+++ b/PHT.php
@@ -233,7 +233,7 @@ class CHPPConnection
 		foreach($result as $val)
 		{
 			$t = explode('=', $val);
-			$$t[0] = urldecode($t[1]);
+			${$t[0]} = urldecode($t[1]);
 		}
 		$this->log("[OAUTH] Request token: ".$oauth_token);
 		$this->log("[OAUTH] Request token secret: ".$oauth_token_secret);
@@ -276,7 +276,7 @@ class CHPPConnection
 		foreach($result as $val)
 		{
 			$t = explode('=', $val);
-			$$t[0] = urldecode($t[1]);
+			${$t[0]} = urldecode($t[1]);
 		}
 		if(isset($oauth_token))
 		{


### PR DESCRIPTION
Changed getSecondaryTeam so that it works with 3 teams or more, added getNumberOfTeams to determine how many there are.

	public function getNumberOfTeams($userId = null)
	{
		$params = array('file'=>'teamdetails', 'version'=>'3.4');
		if($userId !== null)
		{
			$params['userID'] = $userId;
		}
		$url = $this->buildUrl($params);
		$xml = $this->fetchUrl($url);
		if($this->canLog())
		{
			$this->log("URL: ".$url);
		}
	
		$doc = new DOMDocument('1.0', 'UTF-8');
		$doc->loadXml($xml);
	
		$teams = $doc->getElementsByTagName('Team');
		$this->nTeams=$teams->length;
		return $this->nTeams;
	}
		
	/**
	 * Returns HTTeam object with the user's secondary team (or tertiary if $secIndex is specified)
	 *
	 * @param Integer $userId
	 * @param Integer $secIndex
	 * @return HTTeam
	 */
	public function getSecondaryTeam($userId = null, $secIndex=0)
	{
		if(!isset($this->secondaryTeam[$userId]) || $this->secondaryTeam[$userId] === null)
		{
			$params = array('file'=>'teamdetails', 'version'=>'3.4');
			if($userId !== null)
			{
				 $params['userID'] = $userId;
			}
			$url = $this->buildUrl($params);
			$xml = $this->fetchUrl($url);

			$doc = new DOMDocument('1.0', 'UTF-8');
			$doc->loadXml($xml);

			$teams = $doc->getElementsByTagName('Team');
			for($t=0; $t<$teams->length; $t++)
			{
				$txml = new DOMDocument('1.0', 'UTF-8');
				$txml->appendChild($txml->importNode($teams->item($t), true));
				if(strtolower($txml->getElementsByTagName('IsPrimaryClub')->item($t)->nodeValue) == 'true')
				{
					$doc->getElementsByTagName('Teams')->item(0)->removeChild($teams->item($t));
				}
			}
			if($doc->getElementsByTagName('Team')->length)
			{
				$resxml = new DOMDocument('1.0', 'UTF-8');
				$resxml->appendChild($resxml->importNode($teams->item($secIndex), true));
				$this->secondaryTeam[$userId] = new HTTeam($resxml->saveXML());
			}
			else
			{
				return null;
			}
		}
		return $this->secondaryTeam[$userId];
	}