### PR TITLE
Use existing params when fetching a specific results page

### DIFF
--- a/PHT/Xml/Search/Response.php
+++ b/PHT/Xml/Search/Response.php
@@ -211,6 +211,7 @@ class Response extends Xml\File
         if ($page < 0 || $page >= $this->getTotalPage()) {
             return null;
         }
+        $params = $this->params;
         $params['pageIndex'] = $page;
         return Wrapper\Search::search($params);
     }


### PR DESCRIPTION
The current/existing params would be dismissed and getPage()'s only parameters for searching would be pageIndex, which doesn't return results you'd expect.