### PR TITLE
fix the start index in getScout

### DIFF
--- a/PHT/Xml/Team/Youth/Scouts.php
+++ b/PHT/Xml/Team/Youth/Scouts.php
@@ -73,7 +73,7 @@ class Scouts extends Xml\File
     public function getScout($index)
     {
         $index = round($index);
-        if ($index > Config\Config::$forIndex && $index < $this->getScoutNumber() + Config\Config::$forIndex) {
+        if ($index >= Config\Config::$forIndex && $index < $this->getScoutNumber() + Config\Config::$forIndex) {
             $index -= Config\Config::$forIndex;
             $xpath = new \DOMXPath($this->getXml());
             $nodeList = $xpath->query('//Scout');


### PR DESCRIPTION
getScout() was omitting the first scout, because the index of the iteration didn't start with the value Config\Config::$forIndex but with the next one.