### PR TITLE
PHP8: Rename Match to HTMatch

### DIFF
--- a/PHT/PHT.php
+++ b/PHT/PHT.php
@@ -684,11 +684,11 @@ class PHT extends Config\Base
      *
      * @param integer $matchId
      * @param boolean $matchEvents
-     * @return \PHT\Xml\Match
+     * @return \PHT\Xml\HTMatch
      */
     public function getSeniorMatch($matchId, $matchEvents = true)
     {
-        return Wrapper\Match::senior($matchId, $matchEvents);
+        return Wrapper\HTMatch::senior($matchId, $matchEvents);
     }
 
     /**
@@ -696,11 +696,11 @@ class PHT extends Config\Base
      *
      * @param integer $matchId
      * @param boolean $matchEvents
-     * @return \PHT\Xml\Match
+     * @return \PHT\Xml\HTMatch
      */
     public function getYouthMatch($matchId, $matchEvents = true)
     {
-        return Wrapper\Match::youth($matchId, $matchEvents);
+        return Wrapper\HTMatch::youth($matchId, $matchEvents);
     }
 
     /**
@@ -708,11 +708,11 @@ class PHT extends Config\Base
      *
      * @param integer $matchId
      * @param boolean $matchEvents
-     * @return \PHT\Xml\Match
+     * @return \PHT\Xml\HTMatch
      */
     public function getTournamentMatch($matchId, $matchEvents = true)
     {
-        return Wrapper\Match::tournament($matchId, $matchEvents);
+        return Wrapper\HTMatch::tournament($matchId, $matchEvents);
     }
 
     /**
@@ -724,7 +724,7 @@ class PHT extends Config\Base
      */
     public function getSeniorMatchLineup($matchId = null, $teamId = null)
     {
-        return Wrapper\Match::seniorlineup($matchId, $teamId);
+        return Wrapper\HTMatch::seniorlineup($matchId, $teamId);
     }
 
     /**
@@ -736,7 +736,7 @@ class PHT extends Config\Base
      */
     public function getYouthMatchLineup($matchId = null, $teamId = null)
     {
-        return Wrapper\Match::youthlineup($matchId, $teamId);
+        return Wrapper\HTMatch::youthlineup($matchId, $teamId);
     }
 
     /**
@@ -748,7 +748,7 @@ class PHT extends Config\Base
      */
     public function getTournamentMatchLineup($matchId, $teamId = null)
     {
-        return Wrapper\Match::tournamentlineup($matchId, $teamId);
+        return Wrapper\HTMatch::tournamentlineup($matchId, $teamId);
     }
 
     /**
@@ -760,7 +760,7 @@ class PHT extends Config\Base
      */
     public function getSeniorMatchOrders($matchId, $teamId = null)
     {
-        return Wrapper\Match::seniororders($matchId, $teamId);
+        return Wrapper\HTMatch::seniororders($matchId, $teamId);
     }
 
     /**
@@ -772,7 +772,7 @@ class PHT extends Config\Base
      */
     public function getYouthMatchOrders($matchId, $teamId = null)
     {
-        return Wrapper\Match::youthorders($matchId, $teamId);
+        return Wrapper\HTMatch::youthorders($matchId, $teamId);
     }
 
     /**
@@ -784,7 +784,7 @@ class PHT extends Config\Base
      */
     public function getTournamentMatchOrders($matchId, $teamId = null)
     {
-        return Wrapper\Match::tournamentorders($matchId, $teamId);
+        return Wrapper\HTMatch::tournamentorders($matchId, $teamId);
     }
 
     /**
@@ -797,7 +797,7 @@ class PHT extends Config\Base
      */
     public function setMatchOrders(Config\Orders $orders, $teamId = null)
     {
-        return Wrapper\Match::setorders($orders, $teamId);
+        return Wrapper\HTMatch::setorders($orders, $teamId);
     }
 
     /**

--- a/PHT/Wrapper/HTMatch.php
+++ b/PHT/Wrapper/HTMatch.php
@@ -18,12 +18,12 @@ use PHT\Config;
 use PHT\Network;
 use PHT\Exception;
 
-class Match
+class HTMatch
 {
     /**
      * @param integer $id
      * @param boolean $events
-     * @return \PHT\Xml\Match
+     * @return \PHT\Xml\HTMatch
      */
     public static function senior($id, $events = true)
     {
@@ -33,7 +33,7 @@ class Match
     /**
      * @param integer $id
      * @param boolean $events
-     * @return \PHT\Xml\Match
+     * @return \PHT\Xml\HTMatch
      */
     public static function youth($id, $events = true)
     {
@@ -43,7 +43,7 @@ class Match
     /**
      * @param integer $id
      * @param boolean $events
-     * @return \PHT\Xml\Match
+     * @return \PHT\Xml\HTMatch
      */
     public static function tournament($id, $events = true)
     {
@@ -54,7 +54,7 @@ class Match
      * @param string $type
      * @param integer $id
      * @param boolean $events
-     * @return \PHT\Xml\Match
+     * @return \PHT\Xml\HTMatch
      */
     private static function match($type, $id, $events)
     {
@@ -63,7 +63,7 @@ class Match
             $params['matchEvents'] = 'true';
         }
         $url = Network\Request::buildUrl($params);
-        return new Xml\Match(Network\Request::fetchUrl($url));
+        return new Xml\HTMatch(Network\Request::fetchUrl($url));
     }
 
     /**

--- a/PHT/Xml/HTMatch.php
+++ b/PHT/Xml/HTMatch.php
@@ -16,7 +16,7 @@ namespace PHT\Xml;
 use PHT\Utils;
 use PHT\Config;
 
-class Match extends File
+class HTMatch extends File
 {
     private $type;
 

--- a/PHT/Xml/Match/Challenge.php
+++ b/PHT/Xml/Match/Challenge.php
@@ -57,12 +57,12 @@ class Challenge extends Xml\Base
      * Return match details
      *
      * @param boolean $events
-     * @return \PHT\Xml\Match
+     * @return \PHT\Xml\HTMatch
      */
     public function getMatch($events = true)
     {
         if ($this->getId()) {
-            return Wrapper\Match::senior($this->getId(), $events);
+            return Wrapper\HTMatch::senior($this->getId(), $events);
         }
         return null;
     }

--- a/PHT/Xml/Match/Chunk.php
+++ b/PHT/Xml/Match/Chunk.php
@@ -72,16 +72,16 @@ class Chunk extends Xml\Base
      * Return match details
      *
      * @param boolean $events
-     * @return \PHT\Xml\Match
+     * @return \PHT\Xml\HTMatch
      */
     public function getMatch($events = true)
     {
         if ($this->isYouth()) {
-            return Wrapper\Match::youth($this->getId(), $events);
+            return Wrapper\HTMatch::youth($this->getId(), $events);
         } elseif ($this->isTournament()) {
-            return Wrapper\Match::tournament($this->getId(), $events);
+            return Wrapper\HTMatch::tournament($this->getId(), $events);
         }
-        return Wrapper\Match::senior($this->getId(), $events);
+        return Wrapper\HTMatch::senior($this->getId(), $events);
     }
 
     /**

--- a/PHT/Xml/Match/Lineup.php
+++ b/PHT/Xml/Match/Lineup.php
@@ -34,16 +34,16 @@ class Lineup extends Xml\File
      * Return match details
      *
      * @param boolean $events
-     * @return \PHT\Xml\Match
+     * @return \PHT\Xml\HTMatch
      */
     public function getMatch($events = true)
     {
         if (in_array($this->getMatchType(), array(100, 101, 103, 105, 106))) {
-            return Wrapper\Match::youth($this->getMatchId(), $events);
+            return Wrapper\HTMatch::youth($this->getMatchId(), $events);
         } elseif (in_array($this->getMatchType(), array(50, 51, 60, 61, 80))) {
-            return Wrapper\Match::tournament($this->getMatchId(), $events);
+            return Wrapper\HTMatch::tournament($this->getMatchId(), $events);
         }
-        return Wrapper\Match::senior($this->getMatchId(), $events);
+        return Wrapper\HTMatch::senior($this->getMatchId(), $events);
     }
 
     /**

--- a/PHT/Xml/Match/Live.php
+++ b/PHT/Xml/Match/Live.php
@@ -82,14 +82,14 @@ class Live extends Xml\Base
      * Return match details
      *
      * @param boolean $events
-     * @return \PHT\Xml\Match
+     * @return \PHT\Xml\HTMatch
      */
     public function getMatch($events = true)
     {
         if ($this->isYouth()) {
-            return Wrapper\Match::youth($this->getId(), $events);
+            return Wrapper\HTMatch::youth($this->getId(), $events);
         }
-        return Wrapper\Match::senior($this->getId(), $events);
+        return Wrapper\HTMatch::senior($this->getId(), $events);
     }
 
     /**

--- a/PHT/Xml/Match/National.php
+++ b/PHT/Xml/Match/National.php
@@ -46,11 +46,11 @@ class National extends Xml\Base
      * Return match details
      *
      * @param boolean $events
-     * @return \PHT\Xml\Match
+     * @return \PHT\Xml\HTMatch
      */
     public function getMatch($events = true)
     {
-        return Wrapper\Match::senior($this->getId(), $events);
+        return Wrapper\HTMatch::senior($this->getId(), $events);
     }
 
     /**

--- a/PHT/Xml/Match/Orders.php
+++ b/PHT/Xml/Match/Orders.php
@@ -44,16 +44,16 @@ class Orders extends Xml\File
      * Return match details
      *
      * @param boolean $events
-     * @return \PHT\Xml\Match
+     * @return \PHT\Xml\HTMatch
      */
     public function getMatch($events = true)
     {
         if (in_array($this->getMatchType(), array(100, 101, 103, 105, 106))) {
-            return Wrapper\Match::youth($this->getMatchId(), $events);
+            return Wrapper\HTMatch::youth($this->getMatchId(), $events);
         } elseif (in_array($this->getMatchType(), array(50, 51, 60, 61, 80))) {
-            return Wrapper\Match::tournament($this->getMatchId(), $events);
+            return Wrapper\HTMatch::tournament($this->getMatchId(), $events);
         }
-        return Wrapper\Match::senior($this->getMatchId(), $events);
+        return Wrapper\HTMatch::senior($this->getMatchId(), $events);
     }
 
     /**

--- a/PHT/Xml/Match/Team.php
+++ b/PHT/Xml/Match/Team.php
@@ -81,11 +81,11 @@ class Team extends Xml\Base
     public function getLineup()
     {
         if ($this->system == Config\Config::MATCH_YOUTH) {
-            return Wrapper\Match::youthlineup($this->matchId, $this->getId());
+            return Wrapper\HTMatch::youthlineup($this->matchId, $this->getId());
         } elseif ($this->system == Config\Config::MATCH_TOURNAMENT) {
-            return Wrapper\Match::tournamentlineup($this->matchId, $this->getId());
+            return Wrapper\HTMatch::tournamentlineup($this->matchId, $this->getId());
         }
-        return Wrapper\Match::seniorlineup($this->matchId, $this->getId());
+        return Wrapper\HTMatch::seniorlineup($this->matchId, $this->getId());
     }
 
     /**
@@ -96,11 +96,11 @@ class Team extends Xml\Base
     public function getOrders()
     {
         if ($this->system == Config\Config::MATCH_YOUTH) {
-            return Wrapper\Match::youthorders($this->matchId, $this->getId());
+            return Wrapper\HTMatch::youthorders($this->matchId, $this->getId());
         } elseif ($this->system == Config\Config::MATCH_TOURNAMENT) {
-            return Wrapper\Match::tournamentorders($this->matchId, $this->getId());
+            return Wrapper\HTMatch::tournamentorders($this->matchId, $this->getId());
         }
-        return Wrapper\Match::seniororders($this->matchId, $this->getId());
+        return Wrapper\HTMatch::seniororders($this->matchId, $this->getId());
     }
 
     /**
@@ -112,7 +112,7 @@ class Team extends Xml\Base
      */
     public function setOrders(Config\Orders $orders)
     {
-        return Wrapper\Match::setorders($orders, $this->getId());
+        return Wrapper\HTMatch::setorders($orders, $this->getId());
     }
 
     /**

--- a/PHT/Xml/Player/LastMatch.php
+++ b/PHT/Xml/Player/LastMatch.php
@@ -50,14 +50,14 @@ class LastMatch extends Xml\Base
      * Return match
      *
      * @param boolean $events
-     * @return \PHT\Xml\Match
+     * @return \PHT\Xml\HTMatch
      */
     public function getMatch($events = true)
     {
         if ($this->type == Config\Config::MATCH_YOUTH) {
-            return Wrapper\Match::youth($this->getId(), $events);
+            return Wrapper\HTMatch::youth($this->getId(), $events);
         }
-        return Wrapper\Match::senior($this->getId(), $events);
+        return Wrapper\HTMatch::senior($this->getId(), $events);
     }
 
     /**

--- a/PHT/Xml/User/Bookmark/Match.php
+++ b/PHT/Xml/User/Bookmark/Match.php
@@ -43,14 +43,14 @@ class Match extends Xml\User\Bookmark\Element
     /**
      * Return match
      *
-     * @return \PHT\Xml\Match
+     * @return \PHT\Xml\HTMatch
      */
     public function getMatch()
     {
         if ($this->getType() == Config\Config::BOOKMARK_YOUTH_MATCH) {
-            return Wrapper\Match::youth($this->getMatchId());
+            return Wrapper\HTMatch::youth($this->getMatchId());
         }
-        return Wrapper\Match::senior($this->getMatchId());
+        return Wrapper\HTMatch::senior($this->getMatchId());
     }
 
     /**


### PR DESCRIPTION
Renaming PHT/XML/Match and PHT/Wrapper/Match classes to HTMatch, because match is a reserved keyword in PHP8 and PHT throwing "Invalid token" error.